### PR TITLE
Fix reloading of haproxy service

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'modern, resource-driven cookbook for managing haproxy'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url       'https://github.com/nathwill/chef-haproxy-ng'
 issues_url       'https://github.com/nathwill/chef-haproxy-ng/issues'
-version          '0.2.9'
+version          '0.2.10'
 
 %w( fedora redhat centos scientific ubuntu ).each do |platform|
   supports platform

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -23,4 +23,5 @@ end
 
 service 'haproxy' do
   action [:enable, :start]
+  supports :status => :true, :restart => :true, :reload => :true
 end


### PR DESCRIPTION
Explicit activation of the `reload` command (and also `status` and `restart`) is needed to actually have the haproxy service reload its configuration when the default recipe is executed.
