### PR TITLE
Reworked validation

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,7 +17,6 @@
 # limitations under the License.
 
 default['haproxy'].tap do |haproxy|
-  haproxy['validate_at_compile'] = true
   haproxy['install_method'] = 'package'
   haproxy['proxies'] = []
   haproxy['config'] = [

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,6 +17,7 @@
 # limitations under the License.
 
 default['haproxy'].tap do |haproxy|
+  haproxy['validate_at_compile'] = true
   haproxy['install_method'] = 'package'
   haproxy['proxies'] = []
   haproxy['config'] = [

--- a/libraries/00_haproxy_instance.rb
+++ b/libraries/00_haproxy_instance.rb
@@ -31,7 +31,7 @@ class Chef::Resource
         :default => %w( daemon ),
         :callbacks => {
           'is a valid config' => lambda do |spec|
-            Haproxy::Instance.valid_config?(spec)
+            !node['haproxy']['validate_at_compile'] || Haproxy::Instance.valid_config?(spec) # rubocop: disable LineLength
           end
         }
       )
@@ -44,7 +44,7 @@ class Chef::Resource
         :default => ['maxconn 256'],
         :callbacks => {
           'is a valid tuning' => lambda do |spec|
-            Haproxy::Instance.valid_tuning?(spec)
+            !node['haproxy']['validate_at_compile'] || Haproxy::Instance.valid_tuning?(spec) # rubocop: disable LineLength
           end
         }
       )

--- a/libraries/00_haproxy_instance.rb
+++ b/libraries/00_haproxy_instance.rb
@@ -31,7 +31,7 @@ class Chef::Resource
         :default => %w( daemon ),
         :callbacks => {
           'is a valid config' => lambda do |spec|
-            Haproxy::Instance.valid_config?(spec)
+            !validate_at_compile || Haproxy::Instance.valid_config?(spec)
           end
         }
       )
@@ -44,7 +44,7 @@ class Chef::Resource
         :default => ['maxconn 256'],
         :callbacks => {
           'is a valid tuning' => lambda do |spec|
-            Haproxy::Instance.valid_tuning?(spec)
+            !validate_at_compile || Haproxy::Instance.valid_tuning?(spec)
           end
         }
       )
@@ -68,6 +68,14 @@ class Chef::Resource
             spec.all? { |p| p.is_a? Chef::Resource::HaproxyProxy }
           end
         }
+      )
+    end
+
+    def validate_at_compile(arg = nil)
+      set_or_return(
+        :validate_at_compile, arg,
+        :kind_of => [TrueClass, FalseClass],
+        :default => true
       )
     end
   end

--- a/libraries/00_haproxy_instance.rb
+++ b/libraries/00_haproxy_instance.rb
@@ -130,6 +130,11 @@ class Chef::Provider
       @tpl.path "/etc/haproxy/#{@current_resource.name}.cfg"
       @tpl.source 'haproxy.cfg.erb'
       @tpl.variables :instance => @current_resource
+      if Chef::VERSION.to_f >= 12
+        @tpl.verify do |path|
+          "haproxy -q -c -f #{path}"
+        end
+      end
       @tpl.run_action exec_action
       @tpl.updated_by_last_action?
     end

--- a/libraries/00_haproxy_instance.rb
+++ b/libraries/00_haproxy_instance.rb
@@ -131,9 +131,7 @@ class Chef::Provider
       @tpl.source 'haproxy.cfg.erb'
       @tpl.variables :instance => @current_resource
       if Chef::VERSION.to_f >= 12
-        @tpl.verify do |path|
-          "haproxy -q -c -f #{path}"
-        end
+        @tpl.verify { |path| "haproxy -q -c -f #{path}" }
       end
       @tpl.run_action exec_action
       @tpl.updated_by_last_action?

--- a/libraries/00_haproxy_instance.rb
+++ b/libraries/00_haproxy_instance.rb
@@ -31,7 +31,7 @@ class Chef::Resource
         :default => %w( daemon ),
         :callbacks => {
           'is a valid config' => lambda do |spec|
-            !node['haproxy']['validate_at_compile'] || Haproxy::Instance.valid_config?(spec) # rubocop: disable LineLength
+            Haproxy::Instance.valid_config?(spec)
           end
         }
       )
@@ -44,7 +44,7 @@ class Chef::Resource
         :default => ['maxconn 256'],
         :callbacks => {
           'is a valid tuning' => lambda do |spec|
-            !node['haproxy']['validate_at_compile'] || Haproxy::Instance.valid_tuning?(spec) # rubocop: disable LineLength
+            Haproxy::Instance.valid_tuning?(spec)
           end
         }
       )

--- a/libraries/00_haproxy_proxy.rb
+++ b/libraries/00_haproxy_proxy.rb
@@ -32,7 +32,7 @@ class Chef::Resource
         :default => [],
         :callbacks => {
           "is a valid #{type} config" => lambda do |spec|
-            Haproxy::Proxy.valid_config?(spec, type)
+            !node['haproxy']['validate_at_compile'] || Haproxy::Proxy.valid_config?(spec, type) # rubocop: disable LineLength
           end
         }
       )

--- a/libraries/00_haproxy_proxy.rb
+++ b/libraries/00_haproxy_proxy.rb
@@ -32,7 +32,7 @@ class Chef::Resource
         :default => [],
         :callbacks => {
           "is a valid #{type} config" => lambda do |spec|
-            !node['haproxy']['validate_at_compile'] || Haproxy::Proxy.valid_config?(spec, type) # rubocop: disable LineLength
+            Haproxy::Proxy.valid_config?(spec, type)
           end
         }
       )

--- a/libraries/00_haproxy_proxy.rb
+++ b/libraries/00_haproxy_proxy.rb
@@ -32,9 +32,17 @@ class Chef::Resource
         :default => [],
         :callbacks => {
           "is a valid #{type} config" => lambda do |spec|
-            Haproxy::Proxy.valid_config?(spec, type)
+            !validate_at_compile || Haproxy::Proxy.valid_config?(spec, type)
           end
         }
+      )
+    end
+
+    def validate_at_compile(arg = nil)
+      set_or_return(
+        :validate_at_compile, arg,
+        :kind_of => [TrueClass, FalseClass],
+        :default => true
       )
     end
   end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,12 +18,6 @@
 
 include_recipe "#{cookbook_name}::install"
 
-execute 'validate-haproxy_instance-haproxy' do
-  command 'haproxy -c -f /etc/haproxy/haproxy.cfg'
-  notifies :reload, 'service[haproxy]', :delayed
-  action :nothing
-end
-
 my_proxies = node['haproxy']['proxies'].map do |p|
   Haproxy::Helpers.proxy(p, run_context)
 end
@@ -32,7 +26,6 @@ haproxy_instance 'haproxy' do
   config node['haproxy']['config']
   tuning node['haproxy']['tuning']
   proxies my_proxies
-  notifies :run, 'execute[validate-haproxy_instance-haproxy]', :immediately
 end
 
 include_recipe "#{cookbook_name}::service"

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -24,4 +24,6 @@ end
 service 'haproxy' do
   action [:enable, :start]
   supports :status => :true, :restart => :true, :reload => :true
+  subscribes :reload, 'haproxy_instance[haproxy]', :delayed
+  subscribes :reload, 'cookbook_file[/etc/default/haproxy]', :delayed
 end

--- a/test/fixtures/cookbooks/my-lb/recipes/default.rb
+++ b/test/fixtures/cookbooks/my-lb/recipes/default.rb
@@ -88,19 +88,13 @@ end
 # Temporarily disable the validation so we can create a bogus resource.
 # Reusing the actionable proxy test lets us confirm disabling compile-time
 # validation works, without also screwing up the rendered configuration.	
-
-node.default['haproxy']['validate_at_compile'] = false
-
 haproxy_backend 'should_not_exist' do
+  validate_at_compile false
   config [
     'bind 127.0.0.1:8080' # bogus config
   ]
   not_if { true }
 end
-
-node.default['haproxy']['validate_at_compile'] = true
-
-# Back to normal mode
 
 haproxy_backend 'app' do
   mode 'http'

--- a/test/fixtures/cookbooks/my-lb/recipes/default.rb
+++ b/test/fixtures/cookbooks/my-lb/recipes/default.rb
@@ -85,9 +85,22 @@ else
   end
 end
 
+# Temporarily disable the validation so we can create a bogus resource.
+# Reusing the actionable proxy test lets us confirm disabling compile-time
+# validation works, without also screwing up the rendered configuration.	
+
+node.default['haproxy']['validate_at_compile'] = false
+
 haproxy_backend 'should_not_exist' do
+  config [
+    'bind 127.0.0.1:8080' # bogus config
+  ]
   not_if { true }
 end
+
+node.default['haproxy']['validate_at_compile'] = true
+
+# Back to normal mode
 
 haproxy_backend 'app' do
   mode 'http'


### PR DESCRIPTION
Related to https://github.com/nathwill/chef-haproxy-ng/issues/12.
- Permits disabling keyword validation on proxy/instance resources.
- replace execute-resource based validation with Chef 12's verify attribute
