### PR TITLE
consul-template test cookbook

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -35,3 +35,11 @@ suites:
       - centos-6.6
       - centos-7.0
       - fedora-21
+  - name: consul
+    run_list:
+      - recipe[my-consul-lb]
+    excludes:
+      - ubuntu-12.04
+      - ubuntu-14.04
+      - centos-6.6
+      - fedora-21

--- a/Berksfile
+++ b/Berksfile
@@ -4,4 +4,5 @@ metadata
 
 group :integration do
   cookbook 'my-lb', path: 'test/fixtures/cookbooks/my-lb'
+  cookbook 'my-consul-lb', path: 'test/fixtures/cookbooks/my-consul-lb'
 end

--- a/libraries/00_haproxy_instance.rb
+++ b/libraries/00_haproxy_instance.rb
@@ -100,11 +100,11 @@ class Chef::Provider
     def load_current_resource
       @current_resource ||=
         Chef::Resource::HaproxyInstance.new(new_resource.name)
+      @current_resource.verify new_resource.verify
       @current_resource.cookbook new_resource.cookbook
       @current_resource.config new_resource.config
       @current_resource.tuning new_resource.tuning
       @current_resource.debug new_resource.debug
-      @current_resource.verify new_resource.verify
       @current_resource.proxies actionable_proxies(new_resource.proxies)
       @current_resource
     end

--- a/libraries/00_haproxy_proxy.rb
+++ b/libraries/00_haproxy_proxy.rb
@@ -58,6 +58,7 @@ class Chef::Provider
       )
     end
 
+    # rubocop: disable AbcSize
     def load_current_resource
       @current_resource ||= Chef::Resource::HaproxyProxy.new(new_resource.name)
       @current_resource.verify new_resource.verify
@@ -66,6 +67,7 @@ class Chef::Provider
       @current_resource.verify new_resource.verify
       @current_resource
     end
+    # rubocop: enable AbcSize
 
     def action_create
       new_resource.updated_by_last_action(edit_proxy(:create))

--- a/libraries/00_haproxy_proxy.rb
+++ b/libraries/00_haproxy_proxy.rb
@@ -60,6 +60,7 @@ class Chef::Provider
 
     def load_current_resource
       @current_resource ||= Chef::Resource::HaproxyProxy.new(new_resource.name)
+      @current_resource.verify new_resource.verify
       @current_resource.type new_resource.type
       @current_resource.config new_resource.config
       @current_resource.verify new_resource.verify

--- a/libraries/01_haproxy_backend.rb
+++ b/libraries/01_haproxy_backend.rb
@@ -29,6 +29,7 @@ class Chef::Provider
     def load_current_resource
       @current_resource ||=
         Chef::Resource::HaproxyBackend.new(new_resource.name)
+      @current_resource.verify new_resource.verify
       @current_resource.type new_resource.type
       @current_resource.config merged_config(new_resource)
       @current_resource

--- a/libraries/01_haproxy_defaults.rb
+++ b/libraries/01_haproxy_defaults.rb
@@ -28,6 +28,7 @@ class Chef::Provider
     def load_current_resource
       @current_resource ||=
         Chef::Resource::HaproxyDefaults.new(new_resource.name)
+      @current_resource.verify new_resource.verify
       @current_resource.type new_resource.type
       @current_resource.config merged_config(new_resource)
       @current_resource

--- a/libraries/01_haproxy_frontend.rb
+++ b/libraries/01_haproxy_frontend.rb
@@ -29,6 +29,7 @@ class Chef::Provider
     def load_current_resource
       @current_resource ||=
         Chef::Resource::HaproxyFrontend.new(new_resource.name)
+      @current_resource.verify new_resource.verify
       @current_resource.type new_resource.type
       @current_resource.config merged_config(new_resource)
       @current_resource

--- a/libraries/01_haproxy_listen.rb
+++ b/libraries/01_haproxy_listen.rb
@@ -35,6 +35,7 @@ class Chef::Provider
     def load_current_resource
       @current_resource ||=
         Chef::Resource::HaproxyListen.new(new_resource.name)
+      @current_resource.verify new_resource.verify
       @current_resource.type new_resource.type
       @current_resource.config merged_config(new_resource)
       @current_resource

--- a/libraries/01_haproxy_peers.rb
+++ b/libraries/01_haproxy_peers.rb
@@ -38,6 +38,7 @@ end
 
 class Chef::Provider
   class HaproxyPeers < Chef::Provider::HaproxyProxy
+    # rubocop: disable AbcSize
     def load_current_resource
       @current_resource ||=
         Chef::Resource::HaproxyPeers.new(new_resource.name)
@@ -47,6 +48,7 @@ class Chef::Provider
       @current_resource.config merged_config(new_resource)
       @current_resource
     end
+    # rubocop: enable AbcSize
 
     private
 

--- a/libraries/01_haproxy_peers.rb
+++ b/libraries/01_haproxy_peers.rb
@@ -41,6 +41,7 @@ class Chef::Provider
     def load_current_resource
       @current_resource ||=
         Chef::Resource::HaproxyPeers.new(new_resource.name)
+      @current_resource.verify new_resource.verify
       @current_resource.type new_resource.type
       @current_resource.peers new_resource.peers
       @current_resource.config merged_config(new_resource)

--- a/libraries/01_haproxy_userlist.rb
+++ b/libraries/01_haproxy_userlist.rb
@@ -57,6 +57,7 @@ class Chef::Provider
     def load_current_resource
       @current_resource ||=
         Chef::Resource::HaproxyUserlist.new(new_resource.name)
+      @current_resource.verify new_resource.verify
       @current_resource.type new_resource.type
       @current_resource.users new_resource.users
       @current_resource.groups new_resource.groups

--- a/test/fixtures/cookbooks/my-consul-lb/attributes/default.rb
+++ b/test/fixtures/cookbooks/my-consul-lb/attributes/default.rb
@@ -1,1 +1,10 @@
-default['haproxy']['proxies'] = %w( lb L1 TCP mysql HTTP www app should_not_exist )
+
+default['consul']['init_style'] = 'systemd'
+
+default['consul_template']['init_style'] = 'systemd'
+default['consul_template']['service_user'] = 'root'
+default['consul_template']['service_group'] = 'root'
+
+default['haproxy'].tap do |ha|
+  ha['proxies'] = %w( lb L1 TCP mysql HTTP www app should_not_exist )
+end

--- a/test/fixtures/cookbooks/my-consul-lb/attributes/default.rb
+++ b/test/fixtures/cookbooks/my-consul-lb/attributes/default.rb
@@ -1,0 +1,1 @@
+default['haproxy']['proxies'] = %w( lb L1 TCP mysql HTTP www app should_not_exist )

--- a/test/fixtures/cookbooks/my-consul-lb/metadata.rb
+++ b/test/fixtures/cookbooks/my-consul-lb/metadata.rb
@@ -1,4 +1,5 @@
 name 'my-consul-lb'
 
 depends 'haproxy-ng'
+depends 'consul'
 depends 'consul-template'

--- a/test/fixtures/cookbooks/my-consul-lb/metadata.rb
+++ b/test/fixtures/cookbooks/my-consul-lb/metadata.rb
@@ -1,0 +1,4 @@
+name 'my-consul-lb'
+
+depends 'haproxy-ng'
+depends 'consul-template'

--- a/test/fixtures/cookbooks/my-consul-lb/recipes/consul.rb
+++ b/test/fixtures/cookbooks/my-consul-lb/recipes/consul.rb
@@ -1,0 +1,16 @@
+include_recipe 'consul'
+
+consul_service_def 'haproxy-peers' do
+  port 1024
+  notifies :reload, 'service[consul]'
+end
+
+consul_service_def 'mysql' do
+  port 3306
+  notifies :reload, 'service[consul]'
+end
+
+consul_service_def 'my-app' do
+  port 8080
+  notifies :reload, 'service[consul]'
+end

--- a/test/fixtures/cookbooks/my-consul-lb/recipes/consul_template.rb
+++ b/test/fixtures/cookbooks/my-consul-lb/recipes/consul_template.rb
@@ -1,0 +1,11 @@
+
+include_recipe 'consul-template'
+
+consul_template_config 'haproxy' do
+  templates [{
+    source: '/etc/haproxy/consul.cfg',
+    destination: '/etc/haproxy/haproxy.cfg',
+    command: 'systemctl restart haproxy.service'
+  }]
+  notifies :reload, 'service[consul-template]', :delayed
+end

--- a/test/fixtures/cookbooks/my-consul-lb/recipes/consul_template.rb
+++ b/test/fixtures/cookbooks/my-consul-lb/recipes/consul_template.rb
@@ -2,7 +2,7 @@ include_recipe 'consul-template'
 
 consul_template_config 'haproxy' do
   templates [{
-    source: '/etc/haproxy/consul.cfg',
+    source: '/etc/haproxy/consul-template.cfg',
     destination: '/etc/haproxy/haproxy.cfg',
     command: 'systemctl restart haproxy.service'
   }]

--- a/test/fixtures/cookbooks/my-consul-lb/recipes/consul_template.rb
+++ b/test/fixtures/cookbooks/my-consul-lb/recipes/consul_template.rb
@@ -1,4 +1,3 @@
-
 include_recipe 'consul-template'
 
 consul_template_config 'haproxy' do

--- a/test/fixtures/cookbooks/my-consul-lb/recipes/default.rb
+++ b/test/fixtures/cookbooks/my-consul-lb/recipes/default.rb
@@ -1,5 +1,5 @@
 
-%w( haproxy consul_template ).each do |r|
+%w( consul haproxy consul_template ).each do |r|
   include_recipe "#{cookbook_name}::#{r}"
 end
 

--- a/test/fixtures/cookbooks/my-consul-lb/recipes/default.rb
+++ b/test/fixtures/cookbooks/my-consul-lb/recipes/default.rb
@@ -1,0 +1,6 @@
+
+%w( haproxy consul_template ).each do |r|
+  include_recipe "#{cookbook_name}::#{r}"
+end
+
+include_recipe "haproxy-ng::service"

--- a/test/fixtures/cookbooks/my-consul-lb/recipes/haproxy.rb
+++ b/test/fixtures/cookbooks/my-consul-lb/recipes/haproxy.rb
@@ -124,7 +124,7 @@ my_proxies = node['haproxy']['proxies'].map do |p|
   Haproxy::Helpers.proxy(p, run_context)
 end
 
-haproxy_instance 'consul' do
+haproxy_instance 'consul-template' do
   verify false
   config node['haproxy']['config']
   tuning node['haproxy']['tuning']

--- a/test/fixtures/cookbooks/my-consul-lb/recipes/haproxy.rb
+++ b/test/fixtures/cookbooks/my-consul-lb/recipes/haproxy.rb
@@ -1,0 +1,125 @@
+# Exercise all resources and their attributes for testing,
+# even though this generates a pretty silly configuration.
+
+haproxy_peers 'lb' do
+  peers lb_peers
+  not_if { platform?('ubuntu') && node['platform_version'] =~ /1(2|4).04/ }
+end
+
+haproxy_userlist 'L1' do
+  groups [
+    { 'name' => 'G1', 'config' => 'users tiger,scott' },
+    { 'name' => 'G2', 'config' => 'users xdb,scott' }
+  ]
+  users [
+    { 'name' => 'tiger', 'config' => 'insecure-password password123' },
+    { 'name' => 'scott', 'config' => 'insecure-password pa55word123' },
+    { 'name' => 'xdb', 'config' => 'insecure-password hello' }
+  ]
+end
+
+haproxy_listen 'mysql' do
+  mode 'tcp'
+  acls [
+    {
+      'name' => 'inside',
+      'criterion' => 'src 10.0.0.0/8'
+    }
+  ]
+  description 'mysql pool'
+  balance 'leastconn'
+  source node['ipaddress']
+  bind '0.0.0.0:3306'
+  servers mysql_members
+  config [
+    'option mysql-check'
+  ]
+end
+
+haproxy_defaults 'TCP' do
+  mode 'tcp'
+  balance 'leastconn'
+  source node['ipaddress']
+  config [
+    'option clitcpka',
+    'option srvtcpka',
+    'timeout connect 5s',
+    'timeout client 300s',
+    'timeout server 300s'
+  ]
+end
+
+# Temporarily disable the validation so we can create a bogus resource.
+# Reusing the actionable proxy test lets us confirm disabling compile-time
+# validation works, without also screwing up the rendered configuration.	
+haproxy_backend 'should_not_exist' do
+  verify false
+  config [
+    'bind 127.0.0.1:8080' # bogus config
+  ]
+  not_if { true }
+end
+
+haproxy_backend 'app' do
+  mode 'http'
+  acls [
+    {
+      'name' => 'inside',
+      'criterion' => 'src 10.0.0.0/8'
+    }
+  ]
+  description 'app pool'
+  balance 'roundrobin'
+  source node['ipaddress']
+  servers app_members
+  config [
+    'option httpchk GET /health_check HTTP/1.1\r\nHost:\ localhost'
+  ]
+end
+
+haproxy_frontend 'www' do
+  mode 'http'
+  acls [
+    {
+      'name' => 'inside',
+      'criterion' => 'src 10.0.0.0/8'
+    }
+  ]
+  description 'http frontend'
+  bind '*:80'
+  default_backend 'app'
+  use_backends [
+    {
+      'backend' => 'app',
+      'condition' => 'if inside'
+    }
+  ]
+  config [
+    'option clitcpka'
+  ]
+end
+
+haproxy_defaults 'HTTP' do
+  mode 'http'
+  default_backend 'app'
+  balance 'roundrobin'
+  source node['ipaddress']
+  config [
+    'maxconn 2000',
+    'timeout connect 5s',
+    'timeout client 50s',
+    'timeout server 50s'
+  ]
+end
+
+include_recipe "haproxy-ng::install"
+
+my_proxies = node['haproxy']['proxies'].map do |p|
+  Haproxy::Helpers.proxy(p, run_context)
+end
+
+haproxy_instance 'consul' do
+  config node['haproxy']['config']
+  tuning node['haproxy']['tuning']
+  proxies my_proxies
+end

--- a/test/integration/consul/serverspec/default_spec.rb
+++ b/test/integration/consul/serverspec/default_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+describe 'my-consul-lb' do
+  describe 'sets up consul' do
+    describe service('consul') do
+      it { should be_enabled }
+      it { should be_running }
+    end
+
+    describe file('/etc/consul.d/default.json') do
+      its(:content) { should match /server/ }
+    end
+  end
+
+  describe 'sets up consul-template' do
+    describe service('consul-template') do
+      it { should be_enabled }
+      it { should be_running }
+    end
+
+    describe file('/etc/consul-template.d/haproxy') do
+      its(:content) { should match %r{source = "/etc/haproxy/consul.cfg"} }
+      its(:content) { should match %r{destination = "/etc/haproxy/haproxy.cfg"} }
+      its(:content) { should match %r{command = "systemctl restart haproxy.service"} }
+    end
+  end
+
+  describe 'consul-template renders the template' do
+    describe service('haproxy') do
+      it { should be_enabled }
+      it { should be_running }
+    end
+
+    describe file('/etc/haproxy/haproxy.cfg') do
+      its(:content) { should match /peer consul-centos-70.*:1024/ }
+      its(:content) { should match /server consul-centos-70.*:3306/ }
+      its(:content) { should match /server consul-centos-70.*:8080/ }
+    end
+
+    describe command('haproxy -c -f /etc/haproxy/haproxy.cfg') do
+      its(:exit_status) { should eq 0 }
+      its(:stdout) { should match /valid/ }
+      its(:stdout) { should_not match /warn/i }
+    end
+
+    describe port(80) do
+      it { should be_listening }
+    end
+
+    describe port(1024) do
+      it { should be_listening }
+    end
+
+    describe port(3306) do
+      it { should be_listening }
+    end
+  end
+end

--- a/test/integration/consul/serverspec/default_spec.rb
+++ b/test/integration/consul/serverspec/default_spec.rb
@@ -19,7 +19,7 @@ describe 'my-consul-lb' do
     end
 
     describe file('/etc/consul-template.d/haproxy') do
-      its(:content) { should match %r{source = "/etc/haproxy/consul.cfg"} }
+      its(:content) { should match %r{source = "/etc/haproxy/consul-template.cfg"} }
       its(:content) { should match %r{destination = "/etc/haproxy/haproxy.cfg"} }
       its(:content) { should match %r{command = "systemctl restart haproxy.service"} }
     end

--- a/test/integration/consul/serverspec/spec_helper.rb
+++ b/test/integration/consul/serverspec/spec_helper.rb
@@ -1,0 +1,3 @@
+require 'serverspec'
+
+set :backend, :exec


### PR DESCRIPTION
- further exercises the ability to disable config validation (caught some bugs, woo!)
- provides an example of using the haproxy-ng cookbook to render a consul template
