### PR TITLE
Fix. Underlying provider should not modify attributes.

### DIFF
--- a/libraries/haproxy_proxy_all.rb
+++ b/libraries/haproxy_proxy_all.rb
@@ -33,6 +33,7 @@ module Haproxy
       end
 
       def self.merged_config(conf, proxy)
+        conf = conf.is_a?(Chef::Node::ImmutableArray) ? conf.to_a : conf
         conf.unshift("mode #{proxy.mode}") if proxy.mode
         conf
       end

--- a/spec/unit/all_spec.rb
+++ b/spec/unit/all_spec.rb
@@ -15,4 +15,18 @@ describe Haproxy::Proxy::All do
         .merged_config(dummy_defaults.config, dummy_defaults)
     ).to match_array ['mode http', 'option clitcpka']
   end
+
+  it 'works with Chef attributes' do
+    chef_run.node.default['dummy']['attribute'] = [
+      'timeout client 3h',
+      'timeout server 6h'
+    ]
+
+    expect(chef_run.node['dummy']['attribute']).to be_a Chef::Node::ImmutableArray
+
+    expect(
+      Haproxy::Proxy::All
+        .merged_config(chef_run.node['dummy']['attribute'], dummy_defaults)
+    ).to match_array ['mode http', 'timeout client 3h','timeout server 6h']
+  end
 end


### PR DESCRIPTION
This is to fix the following issue:

```
Chef::Exceptions::ImmutableAttributeModification
------------------------------------------------
Node attributes are read-only when you do not specify which precedence level to set.
To set an attribute use code like `node.default["key"] = "value"'
```

When the cookbook user would pass an attribute instead of an array directly to
the `config` attribute.

Signed-off-by: Krzysztof Wilczynski krzysztof.wilczynski@rakuten.com
