### PR TITLE
Fix remaining resources, build upon Pull Request #19.

### DIFF
--- a/libraries/haproxy_helpers.rb
+++ b/libraries/haproxy_helpers.rb
@@ -33,6 +33,10 @@ module Haproxy
       proxies(run_context).find { |p| p.name == name }
     end
 
+    def self.from_immutable_array(value)
+      value.is_a?(Chef::Node::ImmutableArray) ? value.to_a : value
+    end
+
     private
 
     def self.resources(resource, run_context)

--- a/libraries/haproxy_proxy_all.rb
+++ b/libraries/haproxy_proxy_all.rb
@@ -32,10 +32,10 @@ module Haproxy
         )
       end
 
-      def self.merged_config(conf, proxy)
-        conf = conf.is_a?(Chef::Node::ImmutableArray) ? conf.to_a : conf
-        conf.unshift("mode #{proxy.mode}") if proxy.mode
-        conf
+      def self.merged_config(config, proxy)
+        config = Haproxy::Helpers.from_immutable_array(config)
+        config.unshift("mode #{proxy.mode}") if proxy.mode
+        config
       end
     end
   end

--- a/libraries/haproxy_proxy_backend.rb
+++ b/libraries/haproxy_proxy_backend.rb
@@ -53,11 +53,12 @@ module Haproxy
       end
       # rubocop: enable MethodLength
 
-      def self.merged_config(c, backend)
+      def self.merged_config(config, backend)
+        config = Haproxy::Helpers.from_immutable_array(config)
         backend.servers.each do |s|
-          c << "server #{s['name']} #{s['address']}:#{s['port']} #{s['config']}"
+          config << "server #{s['name']} #{s['address']}:#{s['port']} #{s['config']}"
         end
-        c
+        config
       end
     end
   end

--- a/libraries/haproxy_proxy_backend.rb
+++ b/libraries/haproxy_proxy_backend.rb
@@ -53,6 +53,7 @@ module Haproxy
       end
       # rubocop: enable MethodLength
 
+      # rubocop: disable LineLength
       def self.merged_config(config, backend)
         config = Haproxy::Helpers.from_immutable_array(config)
         backend.servers.each do |s|

--- a/libraries/haproxy_proxy_defaults_backend.rb
+++ b/libraries/haproxy_proxy_defaults_backend.rb
@@ -47,10 +47,11 @@ module Haproxy
         )
       end
 
-      def self.merged_config(conf, db)
-        conf.unshift("balance #{db.balance}") if db.balance
-        conf << "source #{db.source}" if db.source
-        conf
+      def self.merged_config(config, backend)
+        config = Haproxy::Helpers.from_immutable_array(config)
+        config.unshift("balance #{backend.balance}") if backend.balance
+        config << "source #{backend.source}" if backend.source
+        config
       end
     end
   end

--- a/libraries/haproxy_proxy_defaults_frontend.rb
+++ b/libraries/haproxy_proxy_defaults_frontend.rb
@@ -37,6 +37,7 @@ module Haproxy
         )
       end
 
+      # rubocop: disable LineLength
       def self.merged_config(config, frontend)
         config = Haproxy::Helpers.from_immutable_array(config)
         config << "default_backend #{frontend.default_backend}" if frontend.default_backend

--- a/libraries/haproxy_proxy_defaults_frontend.rb
+++ b/libraries/haproxy_proxy_defaults_frontend.rb
@@ -37,9 +37,10 @@ module Haproxy
         )
       end
 
-      def self.merged_config(conf, df)
-        conf << "default_backend #{df.default_backend}" if df.default_backend
-        conf
+      def self.merged_config(config, frontend)
+        config = Haproxy::Helpers.from_immutable_array(config)
+        config << "default_backend #{frontend.default_backend}" if frontend.default_backend
+        config
       end
     end
   end

--- a/libraries/haproxy_proxy_frontend.rb
+++ b/libraries/haproxy_proxy_frontend.rb
@@ -49,6 +49,7 @@ module Haproxy
       # rubocop: enable MethodLength
 
       def self.merged_config(config, frontend)
+        config = Haproxy::Helpers.from_immutable_array(config)
         Array(frontend.bind).each do |bind|
           config.unshift("bind #{bind}")
         end

--- a/libraries/haproxy_proxy_non_defaults.rb
+++ b/libraries/haproxy_proxy_non_defaults.rb
@@ -48,6 +48,7 @@ module Haproxy
         )
       end
 
+      # rubocop: disable LineLength
       def self.merged_config(config, non_defaults)
         config = Haproxy::Helpers.from_immutable_array(config)
         config << "description #{non_defaults.description}" if non_defaults.description

--- a/libraries/haproxy_proxy_non_defaults.rb
+++ b/libraries/haproxy_proxy_non_defaults.rb
@@ -48,12 +48,13 @@ module Haproxy
         )
       end
 
-      def self.merged_config(conf, nd)
-        conf << "description #{nd.description}" if nd.description
-        nd.acls.each do |acl|
-          conf << "acl #{acl['name']} #{acl['criterion']}"
+      def self.merged_config(config, non_defaults)
+        config = Haproxy::Helpers.from_immutable_array(config)
+        config << "description #{non_defaults.description}" if non_defaults.description
+        non_defaults.acls.each do |acl|
+          config << "acl #{acl['name']} #{acl['criterion']}"
         end
-        conf
+        config
       end
     end
   end

--- a/spec/unit/backend_spec.rb
+++ b/spec/unit/backend_spec.rb
@@ -18,4 +18,23 @@ describe Haproxy::Proxy::Backend do
         .merged_config(dummy_backend.config, dummy_backend)
     ).to eq(['fullconn 100', 'server app01 1.2.3.4:80 backup', 'server app02 1.2.3.5:80 backup'])
   end
+
+  it 'works with Chef attributes' do
+    chef_run.node.default['dummy']['attribute'] = [
+      'tcp-check connect',
+      'tcp-check expect'
+    ]
+
+    expect(chef_run.node['dummy']['attribute']).to be_a Chef::Node::ImmutableArray
+
+    expect(
+      Haproxy::Proxy::Backend
+        .merged_config(chef_run.node['dummy']['attribute'], dummy_backend)
+    ).to match_array [
+      'server app01 1.2.3.4:80 backup',
+      'server app02 1.2.3.5:80 backup',
+      'tcp-check connect',
+      'tcp-check expect'
+    ]
+  end
 end

--- a/spec/unit/defaults_backend_spec.rb
+++ b/spec/unit/defaults_backend_spec.rb
@@ -16,4 +16,23 @@ describe Haproxy::Proxy::DefaultsBackend do
         .merged_config(dummy_backend.config, dummy_backend)
     ).to match_array ['fullconn 100', 'balance roundrobin', 'source 1.2.3.4']
   end
+
+  it 'works with Chef attributes' do
+    chef_run.node.default['dummy']['attribute'] = [
+      'timeout connect 10s',
+      'timeout server 30s'
+    ]
+
+    expect(chef_run.node['dummy']['attribute']).to be_a Chef::Node::ImmutableArray
+
+    expect(
+      Haproxy::Proxy::DefaultsBackend
+        .merged_config(chef_run.node['dummy']['attribute'], dummy_backend)
+    ).to match_array [
+      'balance roundrobin',
+      'source 1.2.3.4',
+      'timeout connect 10s',
+      'timeout server 30s'
+    ]
+  end
 end

--- a/spec/unit/defaults_frontend_spec.rb
+++ b/spec/unit/defaults_frontend_spec.rb
@@ -15,4 +15,18 @@ describe Haproxy::Proxy::DefaultsFrontend do
         .merged_config(dummy_frontend.config, dummy_frontend)
     ).to match_array ['bind *:80', 'default_backend app']
   end
+
+  it 'works with Chef attributes' do
+    chef_run.node.default['dummy']['attribute'] = [
+      'option tcpka',
+      'option tcplog'
+    ]
+
+    expect(chef_run.node['dummy']['attribute']).to be_a Chef::Node::ImmutableArray
+
+    expect(
+      Haproxy::Proxy::Frontend
+        .merged_config(chef_run.node['dummy']['attribute'], dummy_frontend)
+    ).to match_array ['option tcpka', 'option tcplog']
+  end
 end

--- a/spec/unit/frontend_spec.rb
+++ b/spec/unit/frontend_spec.rb
@@ -16,4 +16,23 @@ describe Haproxy::Proxy::Frontend do
         .merged_config(dummy_frontend.config, dummy_frontend)
     ).to match_array ['bind *:80', 'option clitcpka', 'use_backend dummy if dummy']
   end
+
+  it 'works with Chef attributes' do
+    chef_run.node.default['dummy']['attribute'] = [
+      'timeout http-keep-alive 10s',
+      'timeout http-request 30s'
+    ]
+
+    expect(chef_run.node['dummy']['attribute']).to be_a Chef::Node::ImmutableArray
+
+    expect(
+      Haproxy::Proxy::Frontend
+        .merged_config(chef_run.node['dummy']['attribute'], dummy_frontend)
+    ).to match_array [
+      'bind *:80',
+      'use_backend dummy if dummy',
+      'timeout http-keep-alive 10s',
+      'timeout http-request 30s'
+    ]
+  end
 end

--- a/spec/unit/helpers_spec.rb
+++ b/spec/unit/helpers_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe Haproxy::Helpers do
   let(:chef_run) { ChefSpec::ServerRunner.new.converge('my-lb::default') }
+  let(:immutable_array) { Chef::Node::ImmutableArray.new([1, 'a', {}]) }
 
   it 'returns a valid config block' do
     expect(
@@ -13,5 +14,15 @@ describe Haproxy::Helpers do
     expect(
       Haproxy::Helpers.proxy('app', chef_run.run_context)
     ).to be_a(Chef::Resource::HaproxyProxy)
+  end
+
+  it 'returns an Array given Chef::Node::ImmutableArray' do
+    expect(
+      Haproxy::Helpers.from_immutable_array(immutable_array)
+    ).to be_a(Array)
+
+    expect(
+      Haproxy::Helpers.from_immutable_array(immutable_array)
+    ).to match_array [1, 'a', {}]
   end
 end

--- a/spec/unit/non_defaults_spec.rb
+++ b/spec/unit/non_defaults_spec.rb
@@ -16,4 +16,23 @@ describe Haproxy::Proxy::NonDefaults do
         .merged_config(dummy_listen.config, dummy_listen)
     ).to match_array ['bind *:80', 'description redis cluster', 'acl redis src 1.2.3.4']
   end
+
+  it 'works with Chef attributes' do
+    chef_run.node.default['dummy']['attribute'] = [
+      'hash-type consistent',
+      'ignore-persist if redis'
+    ]
+
+    expect(chef_run.node['dummy']['attribute']).to be_a Chef::Node::ImmutableArray
+
+    expect(
+      Haproxy::Proxy::NonDefaults
+        .merged_config(chef_run.node['dummy']['attribute'], dummy_listen)
+    ).to match_array [
+      'description redis cluster',
+      'acl redis src 1.2.3.4',
+      'hash-type consistent',
+      'ignore-persist if redis'
+    ]
+  end
 end


### PR DESCRIPTION
This is to fix all of the resources that mutate the value that has been passed to them via the resource attribute uniformly (by making them use a common helper), making sure that when a Node attribute is passed they will not mutate the underlying value (otherwise an exception will be raised).

Signed-off-by: Krzysztof Wilczynski krzysztof.wilczynski@linux.com
