### PR TITLE
use the proxy provider-generated config block instead of re-rendering (fixes #26)

### DIFF
--- a/libraries/chef_haproxy_proxy.rb
+++ b/libraries/chef_haproxy_proxy.rb
@@ -20,6 +20,7 @@
 # limitations under the License.
 #
 
+require 'chef/resource'
 require_relative 'haproxy'
 
 class Chef::Resource

--- a/templates/default/haproxy.cfg.erb
+++ b/templates/default/haproxy.cfg.erb
@@ -3,5 +3,5 @@
 <%= Haproxy::Instance.config_block(@instance) %>
 <% @instance.proxies.each do |p| %>
 
-<%= Haproxy::Proxy.config_block(p) %>
+<%= ::File.read(::File.join(Chef::Config['file_cache_path'] || '/tmp', "haproxy.#{p.type}.#{p.name}.cfg")) %>
 <% end %>

--- a/test/fixtures/cookbooks/my-lb/attributes/default.rb
+++ b/test/fixtures/cookbooks/my-lb/attributes/default.rb
@@ -1,1 +1,2 @@
 default['haproxy']['proxies'] = %w( lb L1 TCP mysql HTTP www app should_not_exist )
+default['my-lb']['fe_config'] = ['option clitcpka']

--- a/test/fixtures/cookbooks/my-lb/recipes/default.rb
+++ b/test/fixtures/cookbooks/my-lb/recipes/default.rb
@@ -130,9 +130,7 @@ haproxy_frontend 'www' do
       'condition' => 'if inside'
     }
   ]
-  config [
-    'option clitcpka'
-  ]
+  config node['my-lb']['fe_config']
 end
 
 haproxy_defaults 'HTTP' do


### PR DESCRIPTION
the individual proxy providers merge all resource configs into `@current_resource`'s config before passing to `Haproxy::Proxy#config_block`, but `#merged_config` isn't available for the template used by the instance provider, which is operating on the actual proxy resource, which hasn't had it's config merged with the other attributes if the config attribute is an immutable array.

i'd like to just use [coerce](https://github.com/chef/chef/blob/b972d25ff0df05a96b9cb909fedd9047a4066642/lib/chef/mixin/params_validate.rb#L437), but that's only available in Chef >= 12.5.1.

So, for now, since the proxy providers are doing the right thing, this PR updates the instance-template to source the proxy configs from the pre-rendered proxy configs.

Long term, I'll probably fix this by making the resources responsible for their own #to_s method as part of the ongoing LWRPBase rewrite.
