### PR TITLE
Add an attribute to allow restart or reload service control

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -28,4 +28,5 @@ default['haproxy'].tap do |haproxy|
   haproxy['tuning'] = [
     'maxconn 50000'
   ]
+  haproxy['restart'] = false
 end

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -28,6 +28,11 @@ service 'haproxy' do
   end
   action [:enable, :start]
   supports :status => :true, :restart => :true, :reload => :true
-  subscribes :reload, 'haproxy_instance[haproxy]', :delayed
-  subscribes :reload, 'cookbook_file[/etc/default/haproxy]', :delayed
+  if node['haproxy']['restart']
+    subscribes :restart, 'haproxy_instance[haproxy]', :delayed
+    subscribes :restart, 'cookbook_file[/etc/default/haproxy]', :delayed
+  else
+    subscribes :reload, 'haproxy_instance[haproxy]', :delayed
+    subscribes :reload, 'cookbook_file[/etc/default/haproxy]', :delayed
+  end
 end


### PR DESCRIPTION
Allow restarting haproxy service instead of reloading it, by overriding the node['haproxy']['restart'] attribute.
